### PR TITLE
Support macOS 12

### DIFF
--- a/src/targets/darwin-x86-64/NOTE
+++ b/src/targets/darwin-x86-64/NOTE
@@ -6,8 +6,8 @@ tools, which you can install with:
 
     $ xcode-select --install
 
-Make sure the /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/
+Make sure the /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/
 directory exists.
 
 To build for a different macOS version start by changing paths and options
-in src/sys.h (symlink for src/targets/darwin-x86-64/sys-darwin-x86-64.h).
+in src/sys.h (symlink to src/targets/darwin-x86-64/sys-darwin-x86-64.h).

--- a/src/targets/darwin-x86-64/crt0-darwin-x86-64.s
+++ b/src/targets/darwin-x86-64/crt0-darwin-x86-64.s
@@ -42,12 +42,11 @@ _main:
 	movl	-4(%rbp),%ecx
 	pushq	%rcx		# argc
 	call	Cmain
-	addq	$16,%rsp
 
-	addq    $32, %rsp
-	movq	%rbp,%rsp
-	popq	%rbp
-	ret
+    movq	%rax,%rdi			# rc
+    andq    $~0xf,%rsp
+    call	_exit
+    hlt
 
 # internal switch(expr) routine
 # %rsi = switch table, %rax = expr


### PR DESCRIPTION
 - Generated code terminates with a call to _exit
 - Edit Darwin NOTE for macOS version >= 10.15