### PR TITLE
Support macOS 13+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ configure: clean
 all:
 	cd src && make all
 
+dirs:
+	cd src && make dirs
+
 install: all
 	cd src && make install
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Updated by Guglielmo Nigri
 
 Source code available at: https://github.com/googlielmo/subc
 
-- Darwin target now *stable* (tested on macOS 10.15 and 11.1)
+- Darwin target now *stable* (tested on macOS 10.15 and 15.7)
+- Updated Darwin/macOS support for recent macOS toolchains and
+  releases
 - Ongoing work to update Linux x86-64 target to the latest tool 
   chain
 - Docker support
@@ -368,11 +370,10 @@ executables.
 INSTALLING THE COMPILER
 -----------------------
 
-The easy way would be to set up the PREFIX (and optionally
-SCCDIR and BINDIR) variables in `src/Makefile` to suit your
-taste and then run
+The easy way is to set up the `PREFIX` (and optionally
+`SCCDIR` and `BINDIR`) variables and then run:
 
-    make dirs	# to create the directories
+    make dirs
     make install
 
 If you want to install the SubC compiler manually, you will
@@ -394,6 +395,16 @@ The headers (`include/*`) go to `INSTALLDIR/include`, the library
 To test the installation just re-compile the compiler:
 
     rm scc && scc -o scc *.c
+
+Example: stage a local install under `/private/tmp`:
+
+    make dirs PREFIX=/private/tmp/subc-install-stage
+    make install PREFIX=/private/tmp/subc-install-stage
+
+On Darwin/macOS, you can override the minimum target version used by
+the SubC driver with:
+
+    SUBC_DARWIN_VERSION_MIN=13.0 make tests
 
 
 DOS SUPPORT

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,8 @@ LIBOBJS=lib/init.o lib/abort.o lib/abs.o lib/atexit.o lib/atoi.o \
 
 OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
-	export MACOSX_DEPLOYMENT_TARGET = 10.15
+	MACOSX_DEPLOYMENT_TARGET ?= 10.15
+	export MACOSX_DEPLOYMENT_TARGET
 	export ZERO_AR_DATE = 1
 endif
 
@@ -51,7 +52,7 @@ scc1:	scc0 lib/crt0.o lib/libscc.a $(SRC)
 	./scc0 -o scc1 $(SRC)
 
 scc0:	$(SRC)
-	$(CC) -o scc0 $(SRC)
+	$(CC) $(CFLAGS) -o scc0 $(SRC)
 
 lib:	lib/libscc.a
 

--- a/src/targets/darwin-x86-64/NOTE
+++ b/src/targets/darwin-x86-64/NOTE
@@ -9,5 +9,7 @@ tools, which you can install with:
 Make sure the /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/
 directory exists.
 
-To build for a different macOS version start by changing paths and options
-in src/sys.h (symlink to src/targets/darwin-x86-64/sys-darwin-x86-64.h).
+To build and link for a different macOS version, set
+SUBC_DARWIN_VERSION_MIN before running build/test commands, e.g.:
+
+    $ SUBC_DARWIN_VERSION_MIN=13.0 make tests

--- a/src/targets/darwin-x86-64/sys-darwin-x86-64.h
+++ b/src/targets/darwin-x86-64/sys-darwin-x86-64.h
@@ -4,6 +4,6 @@
  */
 
 #define OS		"Darwin"
-#define ASCMD		"/usr/bin/as -arch x86_64 -mmacosx-version-min=10.15 -g -o %s %s"
-#define LDCMD		"/usr/bin/ld -no_pie -Z -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -arch x86_64 -macosx_version_min 10.15 -o %s %s/lib/%scrt0.o"
+#define ASCMD		"/usr/bin/as -arch x86_64 -mmacosx-version-min=${SUBC_DARWIN_VERSION_MIN:-10.15} -g -o %s %s"
+#define LDCMD		"/usr/bin/ld -no_pie -Z -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -arch x86_64 -macos_version_min ${SUBC_DARWIN_VERSION_MIN:-10.15} -o %s %s/lib/%scrt0.o"
 #define SYSLIBC		"-lc"


### PR DESCRIPTION
 - add top-level `dirs` target delegating to `src/Makefile`
 - update README with current Darwin test status (macOS 15.7)
 - document root-level install flow and staged PREFIX example
 - allow overriding `MACOSX_DEPLOYMENT_TARGET` in `src/Makefile`
 - update Darwin NOTE with `SUBC_DARWIN_VERSION_MIN` usage
 - update Darwin linker flag to `-macos_version_min` and use env fallback